### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   BUILD_TYPE: Release
 


### PR DESCRIPTION
Potential fix for [https://github.com/beercanx/retro-brick-game-raylib/security/code-scanning/1](https://github.com/beercanx/retro-brick-game-raylib/security/code-scanning/1)

To fix this issue, we need to explicitly define a `permissions` block either at the root level of the workflow (applies to all jobs) or within each job that requires specific permissions. Since the jobs in this workflow only perform build steps and upload artifacts, they likely need read access to `contents` and potentially write access for uploading artifacts. We will add a `permissions` block with the least privilege required for each job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
